### PR TITLE
Manual Input enhancement

### DIFF
--- a/R/manualInputs.R
+++ b/R/manualInputs.R
@@ -5,17 +5,48 @@
 #' @param x list of objective, constraints and fieldInfo
 makeCPLEXFile <- function(x){
   tpl <- "%s\n  obj: %s\nSubject To\n  %s\nBounds\n  %s\nGeneral\n  %s\nBinary\n  %s\nEnd\n"
-  ptype = if (x$maximize) 'Maximize' else 'Minimize'
-  bounds = paste(sapply(x$fieldList, function(x){
-    x$upperBound = if (is.null(x$upperBound)) "+inf" else x$upperBound
+  ptype <- if (x$maximize) 'Maximize' else 'Minimize'
+  bounds <- paste(sapply(x$fieldList, function(x){
+    x$upperBound <- if (is.null(x$upperBound)) "Inf" else x$upperBound
+    x$lowerBound <- if (is.null(x$lowerBound)) "0" else x$lowerBound
     sprintf("%s <= %s <= %s", x$lowerBound, x$fieldName, x$upperBound)
   }), collapse = "\n  ")
-  constraints = paste(x$constraints, collapse = "\n  ")
+
+
+  obj <- clean_obj(x$objective, x$fieldList)
+  constraints <- clean_constr(x$constraints)
+
   find_type <- function(type){
     f <- Filter(function(x){x$type == type}, x$fieldList)
-    paste(sapply(f, '[[', 'fieldName'), collapse = '\n  ')
+    paste(sapply(f, '[[', 'fieldName'), collapse = ' ')
   }
-  general = find_type('General')
-  binary = find_type('Binary')
-  sprintf(tpl, ptype, x$objective, constraints, bounds, general, binary)
+  general <- find_type('General')
+  binary <- find_type('Binary')
+  sprintf(tpl, ptype, obj, constraints, bounds, general, binary)
 }
+
+# Helper function that trims "*" from objective
+
+clean_obj <- function(obj, field_list) {
+  field_names <- sapply(field_list, function(x){x$fieldName[[1]]})
+  block <- paste(field_names, collapse="|")
+  pat <- paste0("\\b((?:", block, ")\\*)(?=\\b(?:", block, ")\\b)|\\*")
+  gsub(pat, "\\1", obj, perl=T)
+}
+
+# Helper function that trims "*", "\n" from constraints
+# Using "trim_star" based on the assumption that the constraints are linear
+clean_constr <- function(x) {
+  trimmed_constr <- sapply(x, trim_newline)
+  trimmed_constr <- sapply(trimmed_constr, trim_star)
+  constr_names <- paste0("C", seq(1, length(x)))
+  named_constr   <- paste(constr_names, trimmed_constr, sep = ": ")
+  constraints <- paste(named_constr, collapse = "\n  ")
+  constraints
+}
+
+# trim any "*"
+trim_star <- function(x) gsub("\\*", "", x)
+trim_newline <- function(x) gsub("^\\n+|\\n+$", "", x)
+
+

--- a/tests/testthat/test-manualInput-LP.R
+++ b/tests/testthat/test-manualInput-LP.R
@@ -24,3 +24,29 @@ test_that("Manual Input works for LP", {
   out = capture.output(sol <- AlteryxSolve(payload))
   expect_equal(sol$objval, 76.66667, tolerance = 0.001)
 })
+
+
+# Configuration with "*" and irregular white space
+constraints1 = c(
+  "3*x1 + 4*x2 + 2*x3 <= 60",
+  "2*x1+x2 +2*x3 <= 40",
+  "x1 +3*x2 + 2x3 <= 80"
+)
+objective1 = (
+  "2* x1 +4*x2 + 3x3"
+)
+config1 <- list(
+  constraints = constraints,
+  objective = objective,
+  maximize = TRUE,
+  inputMode = 'manual',
+  solver = 'glpk'
+)
+
+payload1 <- list(config = config1, inputs = NULL)
+
+
+test_that("Manual Input works for LP", {
+  out = capture.output(sol <- AlteryxSolve(payload1))
+  expect_equal(sol$objval, 76.66667, tolerance = 0.001)
+})


### PR DESCRIPTION
- Added 0 as default lower bound
- Changed `+inf` to `Inf` for default upper bound
- Added constraint names for each constraint inequality
- Stripping off new line `\n` for constraint input
- Stripping off `*` for both objective and constraint -- this won't affect when `*` is in between two decision variables, as common in QP's objective