### PR TITLE
Added constraint optimal, slacks; Unified the output interface

### DIFF
--- a/R/processData.R
+++ b/R/processData.R
@@ -71,10 +71,14 @@ idata_to_df <- function(idata){
 #' @keywords internal
 dfToMatrix <- function(df, numCol) {
   if (identical(names(df), c('i', 'j', 'v'))) {
-    m <- as.list(df)
-    m$nrow <- max(df$i)
-    m$ncol <- numCol
-    m <-  structure(m, class = 'simple_triplet_matrix')
+    m <- slam::simple_triplet_matrix(
+      i = df[,'i'],
+      j = df[,'j'],
+      v = df[,'v'],
+      nrow = max(df[,'i']),
+      ncol = numCol,
+      dimnames = NULL
+    )
     m <- fixSlamMatrix(m)
   } else {
     m <- as.simple_triplet_matrix(df)

--- a/R/solveModel.R
+++ b/R/solveModel.R
@@ -10,8 +10,7 @@ solveModel <- function(x, solver, ...){
 
 solveModel.default <- function(x, solver = 'glpk'){
   sol <- ROI::ROI_solve(x, solver = solver)
-#  row_optimals <- as.vector(slam::matprod_simple_triplet_matrix(x$constraints$L, sol$solution))
-  row_optimals <- as.vector(as.matrix(x$constraints$L) %*% sol$solution)
+  row_optimals <- as.vector(slam::matprod_simple_triplet_matrix(x$constraints$L, sol$solution))
   row_slacks   <- x$constraints$rhs - row_optimals
   row_activity <- list(optimals = row_optimals, slacks = row_slacks)
 

--- a/R/solveModel.R
+++ b/R/solveModel.R
@@ -9,7 +9,17 @@ solveModel <- function(x, solver, ...){
 }
 
 solveModel.default <- function(x, solver = 'glpk'){
-  ROI::ROI_solve(x, solver = solver)
+  sol <- ROI::ROI_solve(x, solver = solver)
+  row_optimals <- as.vector(slam::matprod_simple_triplet_matrix(x$constraints$L, sol$solution))
+  row_slacks   <- x$constraints$rhs - row_optimals
+  row_activity <- list(optimals = row_optimals, slacks = row_slacks)
+
+  # Return a list of
+  # - solution
+  # - objval
+  # - status
+  # - row_activity
+  c(sol, row_activity = row_activity)
 }
 
 solveModel.glpkAPI <- function(x, solver = 'glpkAPI', lp_attr){

--- a/R/solveModel.R
+++ b/R/solveModel.R
@@ -89,8 +89,9 @@ solve_glpkAPI <- function(lp, attr) {
 
   return(list(solution = solution,
               objval = objval,
-              sensitivity = df_sen,
-              row_activity = row_activity))
+              status = NUll,
+              row_activity = row_activity,
+              sensitivity = df_sen))
 }
 
 #' Solve model using Gurobi -----

--- a/R/solveModel.R
+++ b/R/solveModel.R
@@ -10,7 +10,8 @@ solveModel <- function(x, solver, ...){
 
 solveModel.default <- function(x, solver = 'glpk'){
   sol <- ROI::ROI_solve(x, solver = solver)
-  row_optimals <- as.vector(slam::matprod_simple_triplet_matrix(x$constraints$L, sol$solution))
+#  row_optimals <- as.vector(slam::matprod_simple_triplet_matrix(x$constraints$L, sol$solution))
+  row_optimals <- as.vector(as.matrix(x$constraints$L) %*% sol$solution)
   row_slacks   <- x$constraints$rhs - row_optimals
   row_activity <- list(optimals = row_optimals, slacks = row_slacks)
 
@@ -89,7 +90,7 @@ solve_glpkAPI <- function(lp, attr) {
 
   return(list(solution = solution,
               objval = objval,
-              status = NUll,
+              status = NULL,
               row_activity = row_activity,
               sensitivity = df_sen))
 }

--- a/R/solveModel.R
+++ b/R/solveModel.R
@@ -19,7 +19,10 @@ solveModel.default <- function(x, solver = 'glpk'){
   # - objval
   # - status
   # - row_activity
-  c(sol, row_activity = row_activity)
+  list(solution = sol$solution,
+       objval = sol$objval,
+       status = sol$status,
+       row_activity = row_activity)
 }
 
 solveModel.glpkAPI <- function(x, solver = 'glpkAPI', lp_attr){
@@ -108,6 +111,16 @@ solve_gurobi <- function(lp) {
     ub = bounds$ub
   )
   soln <- gurobi::gurobi(model)
+
+  row_optimals <- as.vector(model$A %*% soln$x)
+  row_slacks   <- model$rhs - row_optimals
+  row_activity <- list(optimals = row_optimals, slacks = row_slacks)
+
+  return(list(solution = soln$x,
+              objval = soln$objval,
+              status = NULL,
+              row_activity = row_activity))
+
 }
 
 

--- a/R/solveModel.R
+++ b/R/solveModel.R
@@ -36,6 +36,7 @@ solve_glpkAPI <- function(lp, attr) {
   setRowsNamesGLPK(prob, 1:attr$n_constraints, attr$constraint_names)
   setColsNamesGLPK(prob, 1:attr$n_objective_vars, attr$objective_vars_names)
 
+  # TODO: this following setup doesn't support double-sided inequalities.
   lb <- lp$constraints$rhs
   ub <- lb
   type <- lp$constraints$dir
@@ -68,7 +69,15 @@ solve_glpkAPI <- function(lp, attr) {
   # Get optimal value:
   objval <- getObjValGLPK(prob)
 
-  return(list(solution = solution, objval = objval, sensitivity = df_sen))
+  # Get row(constraint) optimal:
+  row_optimals <- getRowsPrimGLPK(prob)
+  row_slacks   <- lp$constraints$rhs - row_optimals
+  row_activity <- list(optimals = row_optimals, slacks = row_slacks)
+
+  return(list(solution = solution,
+              objval = objval,
+              sensitivity = df_sen,
+              row_activity = row_activity))
 }
 
 #' Solve model using Gurobi -----

--- a/tests/testthat/test-fileInput-LP-sensitivity.R
+++ b/tests/testthat/test-fileInput-LP-sensitivity.R
@@ -1,0 +1,19 @@
+context("fileInput, sensitivity")
+
+# Configuration mockup
+config <- list(
+  inputMode = "file",
+  fileType = "CPLEX_LP",
+  filePath = getSampleData("table_chair.lp"),
+  returnSensitivity = TRUE
+)
+
+payload <- list(config = config, inputs = NULL)
+
+test_that("LP sensitivity, file mode (dense), with glpk", {
+  payload$config$solver <- 'glpkAPI'
+  sol <- AlteryxSolve(payload)
+  df_sensitivity <- sol$sensitivity
+  expect_equal(dim(df_sensitivity$constraintsRHS), c(4,10))
+})
+

--- a/tests/testthat/test-fileInput-LP-sensitivity.R
+++ b/tests/testthat/test-fileInput-LP-sensitivity.R
@@ -5,15 +5,19 @@ config <- list(
   inputMode = "file",
   fileType = "CPLEX_LP",
   filePath = getSampleData("table_chair.lp"),
+  solver = "glpkAPI",
   returnSensitivity = TRUE
 )
 
 payload <- list(config = config, inputs = NULL)
+sol <- AlteryxSolve(payload)
 
-test_that("LP sensitivity, file mode (dense), with glpk", {
-  payload$config$solver <- 'glpkAPI'
-  sol <- AlteryxSolve(payload)
+test_that("LP sensitivity, file mode with glpkAPI", {
   df_sensitivity <- sol$sensitivity
   expect_equal(dim(df_sensitivity$constraintsRHS), c(4,10))
 })
 
+test_that("LP row_activity, file mode with glpkAPI", {
+  expect_equal(sol$row_activity$optimals, c(240,100))
+  expect_equal(sol$row_activity$slacks, c(0,0))
+})

--- a/tests/testthat/test-fileInput-LP.R
+++ b/tests/testthat/test-fileInput-LP.R
@@ -11,15 +11,13 @@ config <- list(
 
 
 payload <- list(config = config, inputs = NULL)
-
+row_optimals <- c(1.0,0.0,1.0,0.0,0.0,0.0,1.0,0.0,0.0,14.2)
 
 test_that("Cell Tower LP is solved correctly by glpk", {
   payload$config$solver = 'glpk'
   sol = AlteryxSolve(payload)
   expect_equal(sol$objval, 7051)
-
-  row_optimals <- c(1.0,0.0,1.0,0.0,0.0,0.0,1.0,0.0,0.0,14.2)
-  expect_equal(sol$row_activity.optimals, row_optimals)
+  expect_equal(sol$row_activity$optimals, row_optimals)
 })
 
 
@@ -30,4 +28,5 @@ test_that("Cell Tower LP is solved correctly by gurobi", {
   payload$config$solver = 'gurobi'
   out = capture.output(sol <- AlteryxSolve(payload))
   expect_equal(sol$objval, 7051)
+  expect_equal(sol$row_activity$optimals, row_optimals)
 })

--- a/tests/testthat/test-fileInput-LP.R
+++ b/tests/testthat/test-fileInput-LP.R
@@ -17,6 +17,9 @@ test_that("Cell Tower LP is solved correctly by glpk", {
   payload$config$solver = 'glpk'
   sol = AlteryxSolve(payload)
   expect_equal(sol$objval, 7051)
+
+  row_optimals <- c(1.0,0.0,1.0,0.0,0.0,0.0,1.0,0.0,0.0,14.2)
+  expect_equal(sol$row_activity.optimals, row_optimals)
 })
 
 

--- a/tests/testthat/test-matrixInput-LP-sensitivity.R
+++ b/tests/testthat/test-matrixInput-LP-sensitivity.R
@@ -1,4 +1,4 @@
-context("matrixInput")
+context("matrixInput sensitivity")
 
 ## Mock up configuration and inputs  ----
 config <- list(


### PR DESCRIPTION
### Added constraint optimal and slacks (`row_activity`) for
- ROI
- Gurobi 
- glpkAPI (when returning sensitivity report)

### Unified the output interface
Solutions directly from ROI, Gurobi and glpkAPI have different structures. I've re-arranged the structure of solutions such that the solution is a list of 
- solution
- objval
- status (currently, it's `NULL` for Gurobi and glpkAPI as a placeholder)
- row_activity
  - row_optimals
  - row_slacks (defined as `rhs - row_optimals`, so it can be negative if the `dir` is `>=`)
- sensitivity (if `returnSensitivity == TRUE`)
  - constraintRHS
  - objCoeff